### PR TITLE
refactor: Update backend and frontend for new kanji_data.json structure

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,24 +1,23 @@
 import dotenv from 'dotenv';
 import path from 'path';
-// apps/backend 폴더에 .env 파일이 있다고 가정
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
-
 
 import express, { Request, Response } from 'express';
 import cors from 'cors';
 import fs from 'fs';
-// import path from 'path'; // 이미 위에서 import 함
 import { Pool } from 'pg';
 
-// kanji_data.json의 구조에 기반한 인터페이스
+// 변경된 kanji_data.json 구조에 기반한 인터페이스
 interface KanjiEntry {
-  id?: number; // id가 없을 수도 있음을 가정
-  kanji: string;
-  meanings: string[]; // 배열로 가정
-  kunyomi: string[];
+  id?: number; // 자동 생성되므로 JSON 파일에는 없을 수 있음
+  kanji: string; // 이 필드는 유지된다고 가정
+  korean_meaning: string;
   onyomi: string[];
-  stroke_count: number; // 필드명 가정
-  jlpt_level?: string; // 필드명 및 옵셔널 가정
+  kunyomi: string[];
+  strokes: number;
+  words?: object[]; // JSONB로 저장될 필드
+  example_sentences?: object[]; // JSONB로 저장될 필드
+  // jlpt_level 필드는 새 기준에 없으므로 제거 또는 주석 처리 (여기서는 제거)
 }
 
 const app = express();
@@ -37,61 +36,64 @@ const pool = new Pool({
 
 let kanjiData: KanjiEntry[] = [];
 try {
-  const filePath = path.join(__dirname, '../../../kanji_data.json'); // kanji-app/kanji_data.json
+  const filePath = path.join(__dirname, '../../../kanji_data.json');
   const rawData = fs.readFileSync(filePath, 'utf-8');
   kanjiData = JSON.parse(rawData);
   console.log('Kanji data loaded successfully from JSON.');
 } catch (error) {
   console.error('Error loading kanji_data.json:', error);
-  // kanji_data.json이 없어도 서버는 시작될 수 있도록 오류를 throw하지 않음
 }
 
 async function initializeDatabase() {
   try {
-    // 테이블 컬럼명은 KanjiEntry 인터페이스와 유사하게, 그리고 SQL에 맞게 조정
-    // meanings는 TEXT 타입으로 저장하고, 애플리케이션 레벨에서 join/split 처리 또는 TEXT[] 사용
     await pool.query(`
       CREATE TABLE IF NOT EXISTS kanji_characters (
         id SERIAL PRIMARY KEY,
         kanji VARCHAR(10) NOT NULL UNIQUE,
-        meanings TEXT,
-        kunyomi TEXT[],
+        korean_meaning TEXT,
         onyomi TEXT[],
-        stroke_count INTEGER,
-        jlpt_level VARCHAR(10)
+        kunyomi TEXT[],
+        strokes INTEGER,
+        words JSONB,
+        example_sentences JSONB
       );
     `);
     console.log('Table "kanji_characters" checked/created successfully.');
 
     const { rows } = await pool.query('SELECT COUNT(*) as count FROM kanji_characters');
-    const kanjiCount = parseInt(rows[0].count, 10);
+    const dbKanjiCount = parseInt(rows[0].count, 10);
 
-    if (kanjiData.length > 0 && kanjiCount < kanjiData.length) { // JSON에 데이터가 있고, DB에 일부만 있거나 없을 때 시딩
+    if (kanjiData.length > 0 && dbKanjiCount < kanjiData.length) { // JSON에 데이터가 있고, DB에 일부만 있거나 없을 때 시딩/업데이트
       console.log('Seeding or updating database with kanji data...');
       for (const item of kanjiData) {
         // 필드 존재 여부 확인 및 기본값 제공
-        const meaningsStr = item.meanings && Array.isArray(item.meanings) ? item.meanings.join(', ') : '';
-        const kunyomiArr = item.kunyomi && Array.isArray(item.kunyomi) ? item.kunyomi : [];
+        const koreanMeaning = item.korean_meaning || '';
         const onyomiArr = item.onyomi && Array.isArray(item.onyomi) ? item.onyomi : [];
-        const strokeCount = typeof item.stroke_count === 'number' ? item.stroke_count : null;
-        const jlptLevel = item.jlpt_level || null;
+        const kunyomiArr = item.kunyomi && Array.isArray(item.kunyomi) ? item.kunyomi : [];
+        const strokesNum = typeof item.strokes === 'number' ? item.strokes : null;
+        // words와 example_sentences는 JSON 객체/배열이므로 그대로 전달 (pg 드라이버가 JSONB로 변환)
+        // 만약 undefined일 경우 null로 저장
+        const wordsData = item.words || null;
+        const exampleSentencesData = item.example_sentences || null;
 
         await pool.query(
-          `INSERT INTO kanji_characters (kanji, meanings, kunyomi, onyomi, stroke_count, jlpt_level)
-           VALUES ($1, $2, $3, $4, $5, $6)
+          `INSERT INTO kanji_characters (kanji, korean_meaning, onyomi, kunyomi, strokes, words, example_sentences)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
            ON CONFLICT (kanji) DO UPDATE SET
-             meanings = EXCLUDED.meanings,
-             kunyomi = EXCLUDED.kunyomi,
+             korean_meaning = EXCLUDED.korean_meaning,
              onyomi = EXCLUDED.onyomi,
-             stroke_count = EXCLUDED.stroke_count,
-             jlpt_level = EXCLUDED.jlpt_level;`,
+             kunyomi = EXCLUDED.kunyomi,
+             strokes = EXCLUDED.strokes,
+             words = EXCLUDED.words,
+             example_sentences = EXCLUDED.example_sentences;`,
           [
-            item.kanji,
-            meaningsStr,
-            kunyomiArr,
+            item.kanji, // kanji 필드는 JSON 파일에 존재해야 함
+            koreanMeaning,
             onyomiArr,
-            strokeCount,
-            jlptLevel,
+            kunyomiArr,
+            strokesNum,
+            wordsData,
+            exampleSentencesData,
           ]
         );
       }
@@ -113,13 +115,12 @@ app.get('/', (req: Request, res: Response) => {
 // GET /api/kanji - 모든 한자 목록 반환
 app.get('/api/kanji', async (req: Request, res: Response) => {
   try {
-    const result = await pool.query('SELECT id, kanji, meanings, kunyomi, onyomi, stroke_count, jlpt_level FROM kanji_characters ORDER BY id ASC');
-    const formattedRows = result.rows.map(row => ({
-      ...row,
-      meanings: row.meanings ? row.meanings.split(', ').filter(m => m) : [], // 빈 문자열 제거
-      // kunyomi, onyomi는 이미 배열 타입이므로 변환 불필요
-    }));
-    res.json(formattedRows);
+    // words, example_sentences는 JSONB 타입이므로 그대로 반환됨
+    const result = await pool.query('SELECT id, kanji, korean_meaning, onyomi, kunyomi, strokes, words, example_sentences FROM kanji_characters ORDER BY id ASC');
+    // 이전에는 meanings를 split 했으나, korean_meaning은 문자열이므로 추가 변환 불필요.
+    // onyomi, kunyomi는 DB에서 TEXT[]로 잘 가져옴.
+    // words, example_sentences는 JSONB 객체/배열로 잘 가져옴.
+    res.json(result.rows);
   } catch (error) {
     console.error('Error fetching all kanji:', error);
     res.status(500).json({ error: 'Failed to fetch kanji list' });
@@ -130,32 +131,25 @@ app.get('/api/kanji', async (req: Request, res: Response) => {
 app.get('/api/kanji/:character', async (req: Request, res: Response) => {
   const { character } = req.params;
   try {
-    const result = await pool.query('SELECT id, kanji, meanings, kunyomi, onyomi, stroke_count, jlpt_level FROM kanji_characters WHERE kanji = $1', [character]);
+    const result = await pool.query('SELECT id, kanji, korean_meaning, onyomi, kunyomi, strokes, words, example_sentences FROM kanji_characters WHERE kanji = $1', [character]);
     if (result.rows.length === 0) {
       return res.status(404).json({ error: 'Kanji not found' });
     }
-    const row = result.rows[0];
-    const formattedRow = {
-      ...row,
-      meanings: row.meanings ? row.meanings.split(', ').filter(m => m) : [], // 빈 문자열 제거
-    };
-    res.json(formattedRow);
-  } catch (error) {
+    // 추가 변환 불필요. DB에서 가져온 row를 그대로 사용.
+    res.json(result.rows[0]);
+  } catch (error)
     console.error(`Error fetching kanji ${character}:`, error);
     res.status(500).json({ error: `Failed to fetch kanji ${character}` });
   }
 });
 
-
 pool.connect((err, client, release) => {
   if (err) {
-    // 데이터베이스 연결 실패는 심각한 문제일 수 있으므로, 로깅 후 필요에 따라 프로세스 종료 고려
     console.error('FATAL: Error acquiring client for initial connection test', err.stack);
-    // process.exit(1); // 또는 다른 오류 처리 메커니즘
     return;
   }
   client?.query('SELECT NOW()', (err, result) => {
-    release(); // 항상 client를 release 해야 합니다.
+    release();
     if (err) {
       console.error('Error executing initial query test', err.stack);
       return;
@@ -166,13 +160,11 @@ pool.connect((err, client, release) => {
 
 app.listen(port, async () => {
   console.log(`Backend server is running on http://localhost:${port}`);
-  // 데이터베이스 연결이 준비된 후에 초기화 시도
   try {
-    await pool.query('SELECT 1'); // 간단한 쿼리로 연결 상태 확인
+    await pool.query('SELECT 1');
     console.log('Database connection verified. Initializing database...');
     await initializeDatabase();
   } catch (err) {
     console.error('Failed to connect to database or initialize:', err);
-    // DB 연결 실패 시 서버 시작은 계속되지만, 기능은 제한될 수 있음을 명시
   }
 });


### PR DESCRIPTION
- Modified backend (Express) to align with new field names: korean_meaning, onyomi, kunyomi, strokes, words, example_sentences.
- Updated KanjiEntry interface, database schema (using JSONB for words/sentences), seeding logic, and API responses in `apps/backend/src/index.ts`.
- Modified frontend (React) to use the new field names from the API.
- Updated Kanji interface and JSX data bindings in `apps/frontend/src/App.tsx`.
- Words and example sentences are now displayed as JSON strings in the UI (MVP).